### PR TITLE
Fix missing metadata for kinds not extant in the preferred group

### DIFF
--- a/lib/api-resources.js
+++ b/lib/api-resources.js
@@ -3,9 +3,15 @@
 const KubernetesResource = require('./kubernetes-resource');
 const KubernetesRequest = require('./kubernetes-request');
 
+const { compareResourceVersions } = require('./util');
+
+const _assignWith = require('lodash/assignWith');
 const _forEach = require('lodash/forEach');
+const _get = require('lodash/get');
+const _head = require('lodash/head');
 const _map = require('lodash/map');
 const _reduce = require('lodash/reduce');
+const _union = require('lodash/union');
 
 const CORE_API_ROUTE = '/api';
 const API_GROUPS_ROUTE = '/apis';
@@ -60,18 +66,14 @@ class ApiResources {
         }, {});
     }
 
+    async _getResourceMetaForGroup(group) {
+        const groupName = group.name;
+        const groupVersions = _map(group.versions, v => v.version);
 
-    async _getResourceMetadata(apiGroupList = {}) {
-        const allGroupResources = await Promise.all(_map(apiGroupList.groups, group => {
-            return new Promise(async (resolve, reject) => {
-                const groupName = group.name;
-                const groupVersions = _map(group.versions, v => v.version);
-                const preferredVersion = group.preferredVersion.version;
+        const resourceMetaByVersion = await Promise.all(_map(groupVersions, version =>
+            new Promise(async (resolve, reject) => {
+                const path = groupName === 'core' ? `${CORE_API_ROUTE}/${version}` : `${API_GROUPS_ROUTE}/${groupName}/${version}`;
 
-                // API paths take one of the following two formats:
-                // -- Core api path: `/api/v1`
-                // -- Group api path: `/apis/{group}/{version}`
-                let path = groupName === 'core' ? `${CORE_API_ROUTE}/${preferredVersion}` : `${API_GROUPS_ROUTE}/${groupName}/${preferredVersion}`;
                 let apiResourceList;
 
                 try {
@@ -84,36 +86,71 @@ class ApiResources {
                     return reject(e);
                 }
 
-                const resourceMetadata = {};
-
-                for(const resource of apiResourceList.resources) {
-                    const kind = resource.kind;
-
-                    // Ignore sub-resources of the form "{resource}/scale"
-                    if(resource.name.indexOf('/') >= 0) {
-                        continue;
-                    }
-
-                    resourceMetadata[kind] = {
+                const resourceMetadata = _reduce(apiResourceList.resources, (acc, resource) => ({
+                    ...acc,
+                    [resource.kind]: {
                         isNamespaced: resource.namespaced,
-                        kind,
+                        kind: resource.kind,
                         apiResource: resource.name,
+                        supportsAllNamespaces: resource.verbs.indexOf('list') >= 0,
                         supportedVerbs: resource.verbs,
-                        groups: {},
-                        preferredGroup: groupName
-                    };
+                        preferredGroup: groupName,
+                        groups: {
+                            [groupName]: {
+                                versions: [ version ],
+                                preferredVersion: version
+                            }
+                        },
+                        version
+                    }
+                }), {});
 
-                    // Resources support fetching across all namespaces if it supports the list verb
-                    resourceMetadata[kind].supportsAllNamespaces = resource.verbs.indexOf('list') >= 0;
+                resolve(resourceMetadata);
+            })
+        ));
 
-                    // set the versions and preferredVersion for the group
-                    resourceMetadata[kind]['groups'][groupName] = {
-                        versions: groupVersions,
-                        preferredVersion
-                    };
+        return resourceMetaByVersion;
+    }
+
+    async _getResourceMetadata(apiGroupList = {}) {
+        const allGroupResources = await Promise.all(_map(apiGroupList.groups, group => {
+            return new Promise(async (resolve, reject) => {
+                const resourceMetaForGroup = await this._getResourceMetaForGroup(group);
+
+                let latestGroupResources;
+
+                try {
+                    latestGroupResources = _reduce(
+                        resourceMetaForGroup,
+                        (a, b) => {
+                            return _assignWith({}, a, b, (objValue, srcValue) => {
+                                if(objValue && srcValue) {
+                                    const srcGroup = _get(srcValue, ['groups', group.name ], {});
+                                    const objGroup = _get(objValue, ['groups', group.name ], {});
+                                    const versions = _union(srcGroup.versions || [], objGroup.versions || []);
+
+                                    const newValue = compareResourceVersions(srcGroup.preferredVersion, objGroup.preferredVersion) === 1
+                                        ? srcValue
+                                        : objValue;
+
+                                    return {
+                                        ...newValue,
+                                        groups: {
+                                            [ group.name ]: {
+                                                versions,
+                                                preferredVersion: _head(versions.sort((a, b) => compareResourceVersions(b, a)))
+                                            }
+                                        }
+                                    };
+                                }
+                            });
+                        }, {}
+                    );
+                } catch(e) {
+                    return reject(e);
                 }
 
-                return resolve(resourceMetadata);
+                return resolve(latestGroupResources);
             });
         }));
 

--- a/lib/api-resources.js
+++ b/lib/api-resources.js
@@ -163,18 +163,34 @@ class ApiResources {
         return _reduce(allGroupResources, (acc, resources) => {
             _forEach(resources, resource => {
                 const kind = resource.kind;
-                const group = resource.preferredGroup;
+                const groupName = resource.preferredGroup;
+                const group = resource.groups[groupName];
 
                 if(!acc[kind]) {
                     acc[kind] = resource;
                 }
 
                 // Merge the groups
-                acc[kind]['groups'][group] = resource.groups[group];
+                acc[kind]['groups'][groupName] = group;
 
-                // prefer apps over extensions
-                if(acc[kind].preferredGroup === 'extensions' && group === 'apps') {
-                    acc[kind].preferredGroup = group;
+                const preferredGroupName = acc[kind].preferredGroup;
+                if(!preferredGroupName) {
+                    // if we don't have a preferredGroup, take the current
+                    acc[kind].preferredGroup = groupName;
+                } else {
+                    const preferredGroup = _get(acc, [kind, 'groups', preferredGroupName], {});
+
+                    const versionComparison = compareResourceVersions(
+                        preferredGroup.preferredVersion || '',
+                        group.preferredVersion || ''
+                    );
+
+                    if((preferredGroupName === 'extensions' && groupName !== 'extensions') ||
+                      (groupName !== 'extensions' && versionComparison === -1)) {
+                        // if we have a newer preferredVersion not in 'extensions'
+                        // prefer that
+                        acc[kind].preferredGroup = groupName;
+                    }
                 }
             });
 

--- a/lib/api-resources.js
+++ b/lib/api-resources.js
@@ -6,6 +6,7 @@ const KubernetesRequest = require('./kubernetes-request');
 const { compareResourceVersions } = require('./util');
 
 const _assignWith = require('lodash/assignWith');
+const _filter = require('lodash/filter');
 const _forEach = require('lodash/forEach');
 const _get = require('lodash/get');
 const _head = require('lodash/head');
@@ -86,24 +87,29 @@ class ApiResources {
                     return reject(e);
                 }
 
-                const resourceMetadata = _reduce(apiResourceList.resources, (acc, resource) => ({
-                    ...acc,
-                    [resource.kind]: {
-                        isNamespaced: resource.namespaced,
-                        kind: resource.kind,
-                        apiResource: resource.name,
-                        supportsAllNamespaces: resource.verbs.indexOf('list') >= 0,
-                        supportedVerbs: resource.verbs,
-                        preferredGroup: groupName,
-                        groups: {
-                            [groupName]: {
-                                versions: [ version ],
-                                preferredVersion: version
-                            }
-                        },
-                        version
-                    }
-                }), {});
+                // Ignore sub-resources of the form "${ resource }/scale"
+                const resources = _filter(apiResourceList.resources, r => _get(r, 'name', '').indexOf('/') === -1);
+
+                const resourceMetadata = _reduce(
+                    resources,
+                    (acc, resource) => ({
+                        ...acc,
+                        [resource.kind]: {
+                            isNamespaced: resource.namespaced,
+                            kind: resource.kind,
+                            apiResource: resource.name,
+                            supportsAllNamespaces: resource.verbs.indexOf('list') >= 0,
+                            supportedVerbs: resource.verbs,
+                            preferredGroup: groupName,
+                            groups: {
+                                [groupName]: {
+                                    versions: [ version ],
+                                    preferredVersion: version
+                                }
+                            },
+                            version
+                        }
+                    }), {});
 
                 resolve(resourceMetadata);
             })
@@ -115,40 +121,40 @@ class ApiResources {
     async _getResourceMetadata(apiGroupList = {}) {
         const allGroupResources = await Promise.all(_map(apiGroupList.groups, group => {
             return new Promise(async (resolve, reject) => {
-                const resourceMetaForGroup = await this._getResourceMetaForGroup(group);
-
-                let latestGroupResources;
+                let resourceMetaForGroup;
 
                 try {
-                    latestGroupResources = _reduce(
-                        resourceMetaForGroup,
-                        (a, b) => {
-                            return _assignWith({}, a, b, (objValue, srcValue) => {
-                                if(objValue && srcValue) {
-                                    const srcGroup = _get(srcValue, ['groups', group.name ], {});
-                                    const objGroup = _get(objValue, ['groups', group.name ], {});
-                                    const versions = _union(srcGroup.versions || [], objGroup.versions || []);
-
-                                    const newValue = compareResourceVersions(srcGroup.preferredVersion, objGroup.preferredVersion) === 1
-                                        ? srcValue
-                                        : objValue;
-
-                                    return {
-                                        ...newValue,
-                                        groups: {
-                                            [ group.name ]: {
-                                                versions,
-                                                preferredVersion: _head(versions.sort((a, b) => compareResourceVersions(b, a)))
-                                            }
-                                        }
-                                    };
-                                }
-                            });
-                        }, {}
-                    );
+                    resourceMetaForGroup = await this._getResourceMetaForGroup(group);
                 } catch(e) {
                     return reject(e);
                 }
+
+                const latestGroupResources = _reduce(
+                    resourceMetaForGroup,
+                    (a, b) => {
+                        return _assignWith({}, a, b, (objValue, srcValue) => {
+                            if(objValue && srcValue) {
+                                const srcGroup = _get(srcValue, ['groups', group.name ], {});
+                                const objGroup = _get(objValue, ['groups', group.name ], {});
+                                const versions = _union(srcGroup.versions || [], objGroup.versions || []);
+
+                                const newValue = compareResourceVersions(srcGroup.preferredVersion, objGroup.preferredVersion) === 1
+                                    ? srcValue
+                                    : objValue;
+
+                                return {
+                                    ...newValue,
+                                    groups: {
+                                        [ group.name ]: {
+                                            versions,
+                                            preferredVersion: _head(versions.sort((a, b) => compareResourceVersions(b, a)))
+                                        }
+                                    }
+                                };
+                            }
+                        });
+                    }, {}
+                );
 
                 return resolve(latestGroupResources);
             });


### PR DESCRIPTION
Here's a shot at fixing our CronJob trouble @nicktate.

The previous code made an incorrect assumption that all kinds would be represented across all versions within a group.  This led to Kinds not in the preferred group not being represented in the metadata.  Additionally, the `versions` array within the group was incorrectly specified.

This does make the metadata call for each version in a group (rather than one call for the preferred version) so it's a bit heavier than before.  Additionally, I've done my best to ensure the payload here is equivalent to what was being delivered before but may have overlooked aspects of the format.  

I'm open to suggestions if you don't like the strategy here or this is logically aberrant somehow. 

Fixes https://github.com/containership/cloud.ui/issues/3927
